### PR TITLE
[v0.2] Cross-repo CI trigger + status badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Docs
+name: CI
 on:
   push:
     branches: [master]

--- a/.github/workflows/cross-repo-notify.yml
+++ b/.github/workflows/cross-repo-notify.yml
@@ -1,0 +1,21 @@
+name: Cross-repo CI notify
+on:
+  push:
+    branches: [master]
+
+jobs:
+  dispatch-downstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch ai-store-dkb
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+          repository: songblaq/ai-store-dkb
+          event-type: dkb-upstream-trigger
+      - name: Dispatch agent-prompt-dkb
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+          repository: songblaq/agent-prompt-dkb
+          event-type: dkb-upstream-trigger

--- a/.github/workflows/downstream-trigger.yml
+++ b/.github/workflows/downstream-trigger.yml
@@ -1,0 +1,25 @@
+# Reference template for downstream repos (ai-store-dkb, agent-prompt-dkb).
+# Do not rely on this file as a runnable workflow in those repos — merge the
+# `repository_dispatch` block into `.github/workflows/ci.yml` instead.
+#
+# Example `on:` merge for ci.yml:
+#
+#   on:
+#     push:
+#       branches: [master]
+#     pull_request:
+#       branches: [master]
+#     repository_dispatch:
+#       types: [dkb-upstream-trigger]
+#
+# Upstream senders need CROSS_REPO_DISPATCH_TOKEN (PAT with repo access to targets).
+
+name: Downstream trigger reference
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Template only — merge repository_dispatch into ci.yml in downstream repos."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/songblaq/directive-knowledge-base/actions/workflows/ci.yml/badge.svg)
+
 # Directive Knowledge Base (DKB)
 
 AI 에이전트/스킬/플러그인/워크플로/커맨드 역할 아티팩트를 체계적으로 관리하기 위한 **지식 체계 명세**.

--- a/docs/ci-badges.md
+++ b/docs/ci-badges.md
@@ -1,0 +1,33 @@
+# CI status badge snippets
+
+Use at the top of each repository README (adjust alt text if you prefer).
+
+## directive-knowledge-base
+
+```markdown
+![CI](https://github.com/songblaq/directive-knowledge-base/actions/workflows/ci.yml/badge.svg)
+```
+
+## dkb-runtime
+
+```markdown
+![CI](https://github.com/songblaq/dkb-runtime/actions/workflows/ci.yml/badge.svg)
+```
+
+## ai-store-dkb
+
+```markdown
+![CI](https://github.com/songblaq/ai-store-dkb/actions/workflows/ci.yml/badge.svg)
+```
+
+## agent-prompt-dkb
+
+```markdown
+![CI](https://github.com/songblaq/agent-prompt-dkb/actions/workflows/ci.yml/badge.svg)
+```
+
+## Cross-repo dispatch setup
+
+1. Create a PAT (fine-grained or classic) with permission to trigger workflows on `songblaq/ai-store-dkb` and `songblaq/agent-prompt-dkb`.
+2. In **directive-knowledge-base** and **dkb-runtime**, add repository secret `CROSS_REPO_DISPATCH_TOKEN` with that PAT.
+3. Ensure downstream `ci.yml` includes `repository_dispatch` with `types: [dkb-upstream-trigger]` (see `.github/workflows/downstream-trigger.yml` in this repo).


### PR DESCRIPTION
Implements #10.

- `cross-repo-notify.yml`: on push to `master`, `repository_dispatch` to ai-store-dkb and agent-prompt-dkb (`dkb-upstream-trigger`).
- `downstream-trigger.yml`: reference template (workflow_dispatch only) with merge instructions for downstream `ci.yml`.
- Rename `docs.yml` → `ci.yml` so badge URLs match the standard `ci.yml` pattern.
- README CI badge; `docs/ci-badges.md` for copy-paste snippets and PAT setup.

**Secret:** add `CROSS_REPO_DISPATCH_TOKEN` to this repo (and dkb-runtime) for dispatch to work.

Closes #10

Made with [Cursor](https://cursor.com)